### PR TITLE
Changing the aws_ami data source 

### DIFF
--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -25,7 +25,7 @@ data "aws_ami" "distro" {
 
   filter {
     name   = "name"
-    values = ["CoreOS-stable-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-*"]
   }
 
   filter {
@@ -33,7 +33,7 @@ data "aws_ami" "distro" {
     values = ["hvm"]
   }
 
-  owners = ["595879546273"] #CoreOS
+  owners = ["099720109477"]
 }
 
 //AWS VPC Variables


### PR DESCRIPTION
Changing the aws_ami data source  resource to ubuntu as coreos AMI requires a password login.

PS: variable override is not possible in data_sources